### PR TITLE
Convert to Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 virtualenv
 *.pyc
 build
+dist
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 virtualenv
 *.pyc
+build

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright 2014 Ted Mielczarek
+Copyright 2022 Jelmer Vernooĳ
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/m4.py
+++ b/m4.py
@@ -36,10 +36,6 @@ class eof(str):
 EOF = eof()
 
 
-def endswith(l, e):
-    return l[-len(e):] == e
-
-
 def name(x):
     return x.__name__ if hasattr(x, '__name__') else x
 
@@ -164,10 +160,10 @@ class Lexer:
         self.chars.append(next(self.iter))
         if (
                 self.start_quote != self.end_quote and
-                endswith(self.chars, self.start_quote)
+                self.chars.endswith(self.start_quote)
         ):
             self.nesting_level += 1
-        elif endswith(self.chars, self.end_quote):
+        elif self.chars.endswith(self.end_quote):
             self.nesting_level -= 1
             if self.nesting_level == 0:
                 # strip start/end quote out of the token value

--- a/m4/__init__.py
+++ b/m4/__init__.py
@@ -294,5 +294,4 @@ class Parser:
             self.diversions[diversion] = []
 
 
-if __name__ == '__main__':
-    Parser(sys.stdin.buffer.read()).parse()
+

--- a/m4/__init__.py
+++ b/m4/__init__.py
@@ -6,6 +6,9 @@ from typing import Iterator, Optional, Union
 from collections import defaultdict
 
 
+__version__ = (0, 0, 1)
+
+
 class ParseError(Exception):
     def __init__(self, message):
         self.message = message

--- a/m4/__main__.py
+++ b/m4/__main__.py
@@ -1,0 +1,6 @@
+from . import Parser
+
+import sys
+
+if __name__ == '__main__':
+    Parser(sys.stdin.buffer.read()).parse()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = parse-m4
+description = Parser for M4
+long_description = file:README.md
+version = attr:m4.__version__
+maintainer = Jelmer Vernooij
+maintainer_email = jelmer@jelmer.uk
+license = Apachev2 or later
+url = https://github.cm/jelmer/m4
+classifiers =
+    Development Status :: 4 - Beta
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Operating System :: POSIX
+
+[options]
+packages = find:
+python_requires = >=3.8
+
+[flake8]
+ignore = W504,E203,W503
+
+[mypy]
+ignore_missing_imports = True
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+#!/usr/bin/python3
+from setuptools import setup
+setup()

--- a/simpleconfigure.sh
+++ b/simpleconfigure.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-/usr/bin/m4 -I/usr/share/autoconf2.13 --reload autoconf.m4f configure.in > /tmp/configure
-
-awk '
-/__oline__/ { printf "%d:", NR + 1 }
-           { print }
-' /tmp/configure | sed '
-/__oline__/s/^\([0-9][0-9]*\):\(.*\)__oline__/\2\1/
-' >/tmp/configure2


### PR DESCRIPTION
Convert to Python 3.

Use bytes throughout, since m4 is encoding-agnostic. See
https://www.gnu.org/software/m4/manual/html_node/Syntax.html#Syntax

This also adds some type annotations but isn't consistent about it.
